### PR TITLE
remove password generation from module #5

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -18,4 +18,6 @@ jobs:
           filter_mode: "nofilter" 
 
       - name: tflint
-        uses: devops-infra/action-tflint@master
+        uses: reviewdog/action-tflint@master
+        with:
+          github_token: ${{ secrets.github_token }}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ module "docdb-cluster" {
 
   cluster_name       = "docdb-cluster"
   master_username    = "doc-user"
+  master_password    = "SuperCoolPassword123"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   subnet_group_ids   = ["subnet-0e850eb742a6603fe", "subnet-0af42ab0203c31963", "subnet-0dca788fac5b76a63"]
   security_group_ids = ["sg-056b779af0e7e0129"]
@@ -24,7 +25,7 @@ Module Input Variables
 |----------|:-------------:|:------:|:------ |
 | `cluster_name` |  string | `n/a`| name for the cluster | 
 | `master_username` |  string | `n/a` | name for the master user | 
-| `password_length` |  number | `16` | length of master password to create | 
+| `master_password` |  string | `n/a` | value for the master password | 
 | `instance_class` |  string | `"db.t3.medium"`| documentdb instance class |
 | `instance_count` |  integer | `2` | number of documentdb instances in the cluster | 
 | `subnet_group_ids` |  list | `[]` | list of subnet ids where to create documentdb cluster | 

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,7 +6,7 @@ module "pritunl-docdb-cluster" {
   source             = "../"
   cluster_name       = "pritunl"
   master_username    = "pritunl"
-  master_password    = "SuperCoolPassword123"
+  master_password    = "SuperCoolPassword123" #tfsec:ignore:GEN003
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   subnet_group_ids   = ["subnet-0e850eb742a6603fe", "subnet-0af42ab0203c31963", "subnet-0dca788fac5b76a63"]
   security_group_ids = ["sg-056b779af0e7e0129"]

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -6,6 +6,7 @@ module "pritunl-docdb-cluster" {
   source             = "../"
   cluster_name       = "pritunl"
   master_username    = "pritunl"
+  master_password    = "SuperCoolPassword123"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   subnet_group_ids   = ["subnet-0e850eb742a6603fe", "subnet-0af42ab0203c31963", "subnet-0dca788fac5b76a63"]
   security_group_ids = ["sg-056b779af0e7e0129"]

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,8 @@
-resource "random_password" "master_password" {
-  length           = var.password_length
-  special          = true
-  override_special = "_%@'"
-}
-
 resource "aws_docdb_cluster" "this" {
   cluster_identifier      = var.cluster_name
   engine                  = "docdb"
   master_username         = var.master_username
-  master_password         = random_password.master_password.result
+  master_password         = var.master_password
   backup_retention_period = var.backup_rentetion_period
   preferred_backup_window = var.backup_window
   skip_final_snapshot     = var.skip_final_snapshot

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,7 +29,7 @@ output "master_username" {
 }
 
 output "master_password" {
-  value       = random_password.master_password.result
+  value       = var.master_password
   sensitive   = true
   description = "The cluster password"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "master_username" {
   description = "Username to use for master user"
 }
 
+variable "master_password" {
+  type = string
+  description = "Password to use for the master user"
+}
+
 variable "backup_window" {
   type        = string
   default     = "07:00-09:00"
@@ -72,10 +77,4 @@ variable "security_group_ids" {
   type        = list(string)
   default     = []
   description = "List of security group ids to attach to the cluster"
-}
-
-variable "password_length" {
-  type        = number
-  default     = 16
-  description = "Length of master password"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "master_username" {
 }
 
 variable "master_password" {
-  type = string
+  type        = string
   description = "Password to use for the master user"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.6.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 2.3.0"
-    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
This PR is removing the auto-generate master password for the DocumentDB cluster. We've also introduced a new variable `master_password` which will be used for creating a master password for the DocumentDB cluster.

This PR contains breaking changes and should be released with new major version: `2.0.0`

Closing #5 